### PR TITLE
Improve programatic submission listing

### DIFF
--- a/ssds/cli/staging.py
+++ b/ssds/cli/staging.py
@@ -19,7 +19,8 @@ def upload(args: argparse.Namespace):
     Upload a local directory tree to the staging bucket
     """
     root = os.path.abspath(os.path.normpath(args.path))
-    ssds.Staging.upload(root, args.submission_id, args.name)
+    for ssds_key in ssds.Staging.upload(root, args.submission_id, args.name):
+        print(ssds.Staging.compose_blobstore_url(ssds_key))
 
 @staging_cli.command("list")
 def list(args: argparse.Namespace):
@@ -34,9 +35,9 @@ def list(args: argparse.Namespace):
 })
 def list_submission(args: argparse.Namespace):
     submission_exists = False
-    for key in ssds.Staging.list_submission(args.submission_id):
+    for ssds_key in ssds.Staging.list_submission(args.submission_id):
         submission_exists = True
-        print(key)
+        print(ssds.Staging.compose_blobstore_url(ssds_key))
     if not submission_exists:
         print(f"No submission found for {args.submission_id}")
 

--- a/tests/test_ssds.py
+++ b/tests/test_ssds.py
@@ -50,10 +50,12 @@ class TestSSDS(infra.SuppressWarningsMixin, unittest.TestCase):
             submission_name = "this_is_a_test_submission"
             with self.subTest("aws"):
                 with ssds.Staging.override(ssds.s3, _s3_staging_bucket):
-                    ssds.Staging.upload(root, submission_id, submission_name)
+                    for ssds_key in ssds.Staging.upload(root, submission_id, submission_name):
+                        print(ssds.Staging.compose_blobstore_url(ssds_key))
             with self.subTest("gcp"):
                 with ssds.Staging.override(ssds.gs, _gs_staging_bucket):
-                    ssds.Staging.upload(root, submission_id, submission_name)
+                    for ssds_key in ssds.Staging.upload(root, submission_id, submission_name):
+                        print(ssds.Staging.compose_blobstore_url(ssds_key))
 
     def test_upload_name_length_error(self):
         with tempfile.TemporaryDirectory() as dirname:

--- a/tests/test_ssds.py
+++ b/tests/test_ssds.py
@@ -68,11 +68,13 @@ class TestSSDS(infra.SuppressWarningsMixin, unittest.TestCase):
             with self.subTest("aws"):
                 with ssds.Staging.override(ssds.s3, _s3_staging_bucket):
                     with self.assertRaises(ValueError):
-                        ssds.Staging.upload(root, submission_id, submission_name)
+                        for _ in ssds.Staging.upload(root, submission_id, submission_name):
+                            pass
             with self.subTest("gcp"):
                 with ssds.Staging.override(ssds.gs, _gs_staging_bucket):
                     with self.assertRaises(ValueError):
-                        ssds.Staging.upload(root, submission_id, submission_name)
+                        for _ in ssds.Staging.upload(root, submission_id, submission_name):
+                            pass
 
 
 class TestSSDSChecksum(infra.SuppressWarningsMixin, unittest.TestCase):


### PR DESCRIPTION
Introduce the concept of `ssds_key`:
e.g. `s3://{bucket}/{ssds_prefix}/{ssds_key}`