### PR TITLE
Add cloud native checksum to blobstore

### DIFF
--- a/ssds/blobstore/__init__.py
+++ b/ssds/blobstore/__init__.py
@@ -28,3 +28,6 @@ class BlobStore:
 
     def put(self, bucket_name: str, key: str, data: bytes):
         raise NotImplementedError()
+
+    def cloud_native_checksum(self, bucket_name: str, key: str) -> str:
+        raise NotImplementedError()

--- a/ssds/blobstore/gs.py
+++ b/ssds/blobstore/gs.py
@@ -48,7 +48,7 @@ class GSBlobStore(BlobStore):
         blob = _client().bucket(bucket_name).blob(key)
         blob.upload_from_file(io.BytesIO(data))
 
-    def cloud_native_checksum(self, bucket_name: str, key: str):
+    def cloud_native_checksum(self, bucket_name: str, key: str) -> str:
         return _client().bucket(bucket_name).get_blob(key).crc32c
 
 @lru_cache()

--- a/ssds/blobstore/gs.py
+++ b/ssds/blobstore/gs.py
@@ -48,6 +48,9 @@ class GSBlobStore(BlobStore):
         blob = _client().bucket(bucket_name).blob(key)
         blob.upload_from_file(io.BytesIO(data))
 
+    def cloud_native_checksum(self, bucket_name: str, key: str):
+        return _client().bucket(bucket_name).get_blob(key).crc32c
+
 @lru_cache()
 def _client():
     if not os.environ.get('GOOGLE_CLOUD_PROJECT'):

--- a/ssds/blobstore/s3.py
+++ b/ssds/blobstore/s3.py
@@ -45,6 +45,10 @@ class S3BlobStore(BlobStore):
         blob = aws.resource("s3").Bucket(bucket_name).Object(key)
         blob.upload_fileobj(io.BytesIO(data))
 
+    def cloud_native_checksum(self, bucket_name: str, key: str) -> str:
+        blob = aws.resource("s3").Bucket(bucket_name).Object(key)
+        return blob.e_tag.strip("\"")
+
 def get_s3_multipart_chunk_size(filesize: int):
     """Returns the chunk size of the S3 multipart object, given a file's size."""
     if filesize <= AWS_MAX_MULTIPART_COUNT * AWS_MIN_CHUNK_SIZE:


### PR DESCRIPTION
Convenience method for retrieving cloud native checksums.

depends on #42 #43